### PR TITLE
Fix missing properties

### DIFF
--- a/sqlalchemy-stubs/orm/mapper.pyi
+++ b/sqlalchemy-stubs/orm/mapper.pyi
@@ -1,5 +1,6 @@
 from typing import Any, Optional
 from .interfaces import InspectionAttr
+from .base import class_mapper as class_mapper
 
 NO_ATTRIBUTE: Any = ...
 

--- a/sqlalchemy-stubs/orm/util.pyi
+++ b/sqlalchemy-stubs/orm/util.pyi
@@ -3,7 +3,7 @@ from ..sql.selectable import FromClause
 
 from ..sql import expression
 from ..sql import util as sql_util
-from .base import InspectionAttr as InspectionAttr
+from .base import InspectionAttr as InspectionAttr, object_mapper as object_mapper
 
 all_cascades: Any = ...
 


### PR DESCRIPTION
`orm/__init__.pyi` expects these properties to exist which follows how SQLAlchemy imports them