### PR TITLE
Better mixins support

### DIFF
--- a/sqlmypy.py
+++ b/sqlmypy.py
@@ -199,7 +199,7 @@ def model_hook(ctx: FunctionContext) -> Type:
           argument types is 'Any'.
     """
     assert isinstance(ctx.default_return_type, Instance)
-    model: TypeInfo = ctx.default_return_type.type
+    model = ctx.default_return_type.type
     metadata = model.metadata.get('sqlalchemy')
     if not metadata or not metadata.get('generated_init'):
         return ctx.default_return_type

--- a/test/test-data/sqlalchemy-plugin-features.test
+++ b/test/test-data/sqlalchemy-plugin-features.test
@@ -50,6 +50,53 @@ class Base:
     ...
 [out]
 
+[case testModelInitMixin]
+
+from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+class HasId:
+    id = Column(Integer, primary_key=True)
+
+
+class User(Base, HasId):
+    __tablename__ = 'users'
+
+    name = Column(String, nullable=False)
+
+
+user = User(id=123, name="John Doe")
+
+[out]
+
+[case testModelInitProperMro]
+
+from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+class Defaults:
+    id = Column(Integer, primary_key=True)
+
+
+class User(Base, Defaults):
+    __tablename__ = 'users'
+
+    # By default mypy will complain about Column[str] not being compatible with Column[int].
+    # Adding "ignore" should allow us to override column type.
+    id = Column(String, primary_key=True)  # type: ignore
+    name = Column(String, nullable=False)
+
+
+User(id='stringish-id')
+User(id=123)
+
+[out]
+main:21: error: Incompatible type for "id" of "User" (got "int", expected "str")
+
 [case testModelInitRelationship]
 from typing import TYPE_CHECKING, List
 

--- a/test/test-data/sqlalchemy-plugin-features.test
+++ b/test/test-data/sqlalchemy-plugin-features.test
@@ -60,15 +60,13 @@ Base = declarative_base()
 class HasId:
     id = Column(Integer, primary_key=True)
 
-
 class User(Base, HasId):
     __tablename__ = 'users'
 
     name = Column(String, nullable=False)
 
-
 user = User(id=123, name="John Doe")
-
+reveal_type(user.id)  # N: Revealed type is 'builtins.int'
 [out]
 
 [case testModelInitProperMro]
@@ -81,7 +79,6 @@ Base = declarative_base()
 class Defaults:
     id = Column(Integer, primary_key=True)
 
-
 class User(Base, Defaults):
     __tablename__ = 'users'
 
@@ -90,12 +87,9 @@ class User(Base, Defaults):
     id = Column(String, primary_key=True)  # type: ignore
     name = Column(String, nullable=False)
 
-
 User(id='stringish-id')
-User(id=123)
-
+User(id=123)  # E: Incompatible type for "id" of "User" (got "int", expected "str")
 [out]
-main:21: error: Incompatible type for "id" of "User" (got "int", expected "str")
 
 [case testModelInitRelationship]
 from typing import TYPE_CHECKING, List

--- a/test/test-data/sqlalchemy-plugin-features.test
+++ b/test/test-data/sqlalchemy-plugin-features.test
@@ -66,7 +66,7 @@ class User(Base, HasId):
     name = Column(String, nullable=False)
 
 user = User(id=123, name="John Doe")
-reveal_type(user.id)  # N: Revealed type is 'builtins.int'
+reveal_type(user.id)  # N: Revealed type is 'builtins.int*'
 [out]
 
 [case testModelInitProperMro]


### PR DESCRIPTION
This addresses #75 by looking at all columns available in mro, not just topmost model.

It doesn't address the rest of the "mixins" story such as `declared_attr`.