### PR TITLE
Use list for relationship(uselist=True) instead of iterable

### DIFF
--- a/sqlmypy.py
+++ b/sqlmypy.py
@@ -372,7 +372,7 @@ def relationship_hook(ctx: FunctionContext) -> Type:
     # We figured out, the model type. Now check if we need to wrap it in Iterable
     if uselist_arg:
         if parse_bool(uselist_arg):
-            new_arg = ctx.api.named_generic_type('typing.Iterable', [new_arg])
+            new_arg = ctx.api.named_generic_type('builtins.list', [new_arg])
     else:
         if has_annotation:
             # If there is an annotation we use it as a source of truth.


### PR DESCRIPTION
Right now `relationship(uselist=True)` uses `typing.Iterable`, which breaks most of our code.

Relationship configuration is described in greater detail here: https://docs.sqlalchemy.org/en/13/orm/collections.html

Right now this PR just replaces `typing.Iterable` with `list`.

What I plan to do in this PR:

- [x] default to `list` when using `uselist=True`
- [ ] use `collection_class` argument to customize collection class if present (simple type)

What can be done later:
- support `dynamic` loader and `query_class` parameters (when #81 gets accepted)
- support dict-like collections (`attribute_mapped_collection`, `column_mapped_collection`, `mapped_collection`)