### PR TITLE
Type relationship as list

### DIFF
--- a/sqlmypy.py
+++ b/sqlmypy.py
@@ -396,10 +396,10 @@ def relationship_hook(ctx: FunctionContext) -> Type:
             # Something complex, stay silent for now.
             new_arg = AnyType(TypeOfAny.special_form)
 
-    # We figured out, the model type. Now check if we need to wrap it in Iterable
+    # We figured out, the model type. Now check if we need to wrap it in List
     if uselist_arg:
         if parse_bool(uselist_arg):
-            new_arg = ctx.api.named_generic_type('typing.Iterable', [new_arg])
+            new_arg = ctx.api.named_generic_type('builtins.list', [new_arg])
     else:
         if has_annotation:
             # If there is an annotation we use it as a source of truth.

--- a/test/test-data/sqlalchemy-plugin-features.test
+++ b/test/test-data/sqlalchemy-plugin-features.test
@@ -178,6 +178,7 @@ class Other(Base):
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import relationship, RelationshipProperty
+from typing import List
 
 Base = declarative_base()
 

--- a/test/test-data/sqlalchemy-plugin-features.test
+++ b/test/test-data/sqlalchemy-plugin-features.test
@@ -131,7 +131,6 @@ Base = declarative_base()
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import relationship, RelationshipProperty
-from typing import Iterable
 
 Base = declarative_base()
 
@@ -144,7 +143,7 @@ class User(Base):
 
 user = User()
 reveal_type(user.first_other)  # N: Revealed type is 'main.Other*'
-reveal_type(user.second_other)  # N: Revealed type is 'typing.Iterable*[main.Other]'
+reveal_type(user.second_other)  # N: Revealed type is 'builtins.list*[main.Other]'
 
 class Other(Base):
     __tablename__ = 'other'
@@ -155,7 +154,6 @@ class Other(Base):
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import relationship, RelationshipProperty
-from typing import Iterable
 
 Base = declarative_base()
 
@@ -169,7 +167,7 @@ class User(Base):
 
 user = User()
 reveal_type(user.first_other)  # N: Revealed type is 'main.Other*'
-reveal_type(user.second_other)  # N: Revealed type is 'typing.Iterable*[main.Other]'
+reveal_type(user.second_other)  # N: Revealed type is 'builtins.list*[main.Other]'
 
 class Other(Base):
     __tablename__ = 'other'
@@ -180,7 +178,6 @@ class Other(Base):
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import relationship, RelationshipProperty
-from typing import Iterable
 
 Base = declarative_base()
 
@@ -188,9 +185,9 @@ class User(Base):
     __tablename__ = 'users'
     id = Column(Integer(), primary_key=True)
     first_other: RelationshipProperty[Other] = relationship('Other')
-    second_other: RelationshipProperty[Iterable[Other]] = relationship(Other, uselist=True)
+    second_other: RelationshipProperty[List[Other]] = relationship(Other, uselist=True)
     third_other: RelationshipProperty[Other] = relationship(Other, uselist=False)
-    bad_other: RelationshipProperty[Other] = relationship('Other', uselist=True)  # E: Incompatible types in assignment (expression has type "RelationshipProperty[Iterable[Other]]", variable has type "RelationshipProperty[Other]")
+    bad_other: RelationshipProperty[Other] = relationship('Other', uselist=True)  # E: Incompatible types in assignment (expression has type "RelationshipProperty[List[Other]]", variable has type "RelationshipProperty[Other]")
 
 class Other(Base):
     __tablename__ = 'other'


### PR DESCRIPTION
:sparkles: Type relationship as list.

Currently, the plugin types relationships with `uselist` as `Iterable[X]`, but these relationships actually expose a `list` with list semantics, including `.append()`, assignments, etc.

This PR updates the plugin to type those relationships with `List[X]` instead of `Iterable[X]`.

Ref: https://docs.sqlalchemy.org/en/13/orm/relationship_api.html#sqlalchemy.orm.relationship.params.uselist

Ref of usage with assignment: https://docs.sqlalchemy.org/en/13/orm/tutorial.html#working-with-related-objects
Ref of usage with append: https://docs.sqlalchemy.org/en/13/orm/tutorial.html#building-a-many-to-many-relationship

---

**Note**: I'm by no means expert in mypy internals and its plugins, I'm not 100% sure the usage of `ctx.api.named_generic_type('builtins.list', [new_arg])` is correct here, but I see that seems to be how it's used by mypy: https://github.com/python/mypy/blob/master/mypy/plugins/ctypes.py#L158
