### PR TITLE
Update external/mypy to v0.971

### DIFF
--- a/sqlalchemy-stubs/util/_collections.pyi
+++ b/sqlalchemy-stubs/util/_collections.pyi
@@ -1,3 +1,4 @@
+from _typeshed import SupportsKeysAndGetItem
 from typing import (
     Any, Optional, Union, FrozenSet, Generic, Type, TypeVar, Set, Iterator, Iterable, Tuple, List, Callable, Dict, Mapping,
     AbstractSet, overload
@@ -82,7 +83,7 @@ class OrderedDict(Dict[_KT, _VT]):
     else:
         def sort(self, *, key: Optional[Callable[[_VT], Any]] = ..., reverse: bool = ...) -> None: ...
     @overload
-    def update(self, ____sequence: Mapping[_KT, _VT], **kwargs: _VT) -> None: ...
+    def update(self, ____sequence: SupportsKeysAndGetItem[_KT, _VT], **kwargs: _VT) -> None: ...
     @overload
     def update(self, ____sequence: Iterable[Tuple[_KT, _VT]], **kwargs: _VT) -> None: ...
     @overload

--- a/test/test-data/sqlalchemy-basics.test
+++ b/test/test-data/sqlalchemy-basics.test
@@ -5,13 +5,13 @@ from sqlalchemy import Column, Integer, String
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer, primary_key=True)
     name = Column(String)
 
 user: User
-reveal_type(user.id)  # N: Revealed type is 'builtins.int*'
-reveal_type(User.name)  # N: Revealed type is 'sqlalchemy.sql.schema.Column[Union[builtins.str, None]]'
+reveal_type(user.id)  # N: Revealed type is "builtins.int"
+reveal_type(User.name)  # N: Revealed type is "sqlalchemy.sql.schema.Column[Union[builtins.str, None]]"
 [out]
 
 [case testTypeEngineCovariance]
@@ -19,10 +19,10 @@ from sqlalchemy import Column, Integer, String
 from sqlalchemy.sql.type_api import TypeEngine
 
 from typing import TypeVar, Optional
-T = TypeVar('T', bound=Optional[int])
+T = TypeVar("T", bound=Optional[int])
 
 def func(tp: TypeEngine[T]) -> T: ...
-reveal_type(func(Integer()))  # N: Revealed type is 'builtins.int*'
+reveal_type(func(Integer()))  # N: Revealed type is "builtins.int"
 func(String())  # E: Value of type variable "T" of "func" cannot be "str"
 [out]
 
@@ -33,13 +33,13 @@ from sqlalchemy import Column, Integer, String
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
     name = Column(String(), nullable=False)
 
 user: User
-reveal_type(user.id)  # N: Revealed type is 'builtins.int*'
-reveal_type(User.name)  # N: Revealed type is 'sqlalchemy.sql.schema.Column[builtins.str*]'
+reveal_type(user.id)  # N: Revealed type is "builtins.int"
+reveal_type(User.name)  # N: Revealed type is "sqlalchemy.sql.schema.Column[builtins.str]"
 [out]
 
 [case testColumnFieldsRelationship]
@@ -52,23 +52,23 @@ if TYPE_CHECKING:
     from other import Other
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
     name = Column(String())
-    other = relationship('Other', uselist=False)
-    another: RelationshipProperty[Other] = relationship('Other')
+    other = relationship("Other", uselist=False)
+    another: RelationshipProperty[Other] = relationship("Other")
 
 user: User
-reveal_type(user.other)  # N: Revealed type is 'other.Other*'
-reveal_type(User.other)  # N: Revealed type is 'sqlalchemy.orm.relationships.RelationshipProperty[other.Other*]'
-reveal_type(user.other.name)  # N: Revealed type is 'builtins.str*'
+reveal_type(user.other)  # N: Revealed type is "other.Other"
+reveal_type(User.other)  # N: Revealed type is "sqlalchemy.orm.relationships.RelationshipProperty[other.Other]"
+reveal_type(user.other.name)  # N: Revealed type is "builtins.str"
 
 [file other.py]
 from sqlalchemy import Column, Integer, String
 from base import Base
 
 class Other(Base):
-    __tablename__ = 'other'
+    __tablename__ = "other"
     id = Column(Integer(), primary_key=True)
     name = Column(String(), nullable=False)
 
@@ -82,11 +82,11 @@ from typing import Any
 from sqlalchemy import Table, MetaData, Column, Integer, String
 
 metadata = MetaData()
-users = Table('users', metadata,
-              Column('id', Integer, primary_key=True),
-              Column('name', String))
+users = Table("users", metadata,
+              Column("id", Integer, primary_key=True),
+              Column("name", String))
 
-reveal_type(users.c.name)  # N: Revealed type is 'sqlalchemy.sql.schema.Column*[Any]'
+reveal_type(users.c.name)  # N: Revealed type is "sqlalchemy.sql.schema.Column[Any]"
 [out]
 
 [case testColumnFieldsInferred_python2]
@@ -96,13 +96,13 @@ from sqlalchemy import Column, Integer, String
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer, primary_key=True)
     name = Column(String)
 
 user = User()
-reveal_type(user.id)  # N: Revealed type is 'builtins.int*'
-reveal_type(User.name)  # N: Revealed type is 'sqlalchemy.sql.schema.Column[Union[builtins.unicode, None]]'
+reveal_type(user.id)  # N: Revealed type is "builtins.int"
+reveal_type(User.name)  # N: Revealed type is "sqlalchemy.sql.schema.Column[Union[builtins.unicode, None]]"
 [out]
 
 [case testColumnFieldsInferredInstance_python2]
@@ -112,13 +112,13 @@ from sqlalchemy import Column, Integer, String
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
-    name = Column(String(), default='John Doe')
+    name = Column(String(), default="John Doe")
 
 user = User()
-reveal_type(user.id)  # N: Revealed type is 'builtins.int*'
-reveal_type(User.name)  # N: Revealed type is 'sqlalchemy.sql.schema.Column[builtins.unicode*]'
+reveal_type(user.id)  # N: Revealed type is "builtins.int"
+reveal_type(User.name)  # N: Revealed type is "sqlalchemy.sql.schema.Column[builtins.unicode]"
 [out]
 
 [case testRelationshipStrictEquality]
@@ -132,12 +132,12 @@ Base = declarative_base()
 session = Session()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
-    other = relationship('Other')
+    other = relationship("Other")
 
 class Other(Base):
-    __tablename__ = 'other'
+    __tablename__ = "other"
     id = Column(Integer(), primary_key=True)
 
 other: Other
@@ -158,9 +158,9 @@ class User(Base):
     name: CS
 
 user: User
-reveal_type(user.id)  # N: Revealed type is 'builtins.int*'
-reveal_type(User.name)  # N: Revealed type is 'sqlalchemy.sql.schema.Column[builtins.str*]'
+reveal_type(user.id)  # N: Revealed type is "builtins.int"
+reveal_type(User.name)  # N: Revealed type is "sqlalchemy.sql.schema.Column[builtins.str]"
 User(id=1)
-User(id='no')  # E: Incompatible type for "id" of "User" (got "str", expected "int")
+User(id="no")  # E: Incompatible type for "id" of "User" (got "str", expected "int")
 User(undefined=0)  # E: Unexpected column "undefined" for model "User"
 [out]

--- a/test/test-data/sqlalchemy-plugin-features.test
+++ b/test/test-data/sqlalchemy-plugin-features.test
@@ -5,7 +5,7 @@ from base import Base
 from typing import Optional
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
     name = Column(String())
 
@@ -30,7 +30,7 @@ from base import Base
 from typing import Optional
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
     name = Column(String())
 
@@ -61,12 +61,12 @@ class HasId:
     id = Column(Integer, primary_key=True)
 
 class User(Base, HasId):
-    __tablename__ = 'users'
+    __tablename__ = "users"
 
     name = Column(String, nullable=False)
 
 user = User(id=123, name="John Doe")
-reveal_type(user.id)  # N: Revealed type is 'builtins.int*'
+reveal_type(user.id)  # N: Revealed type is "builtins.int"
 [out]
 
 [case testModelInitProperMro]
@@ -80,14 +80,14 @@ class Defaults:
     id = Column(Integer, primary_key=True)
 
 class User(Base, Defaults):
-    __tablename__ = 'users'
+    __tablename__ = "users"
 
     # By default mypy will complain about Column[str] not being compatible with Column[int].
     # Adding "ignore" should allow us to override column type.
     id = Column(String, primary_key=True)  # type: ignore
     name = Column(String, nullable=False)
 
-User(id='stringish-id')
+User(id="stringish-id")
 User(id=123)  # E: Incompatible type for "id" of "User" (got "int", expected "str")
 [out]
 
@@ -101,9 +101,9 @@ if TYPE_CHECKING:
     from other import Other
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
-    other = relationship('Other', uselist=False)
+    other = relationship("Other", uselist=False)
     many_others = relationship(Other, uselist=True)
 
 o: Other
@@ -118,7 +118,7 @@ from sqlalchemy import Column, Integer, String
 from base import Base
 
 class Other(Base):
-    __tablename__ = 'other'
+    __tablename__ = "other"
     id = Column(Integer(), primary_key=True)
     name = Column(String(), nullable=False)
 
@@ -135,18 +135,18 @@ from sqlalchemy.orm import relationship, RelationshipProperty
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
     first_other = relationship(Other)
     second_other = relationship(Other, uselist=True)
     bad_other: RelationshipProperty[int] = relationship(Other, uselist=False)  # E: Incompatible types in assignment (expression has type "RelationshipProperty[Other]", variable has type "RelationshipProperty[int]")
 
 user = User()
-reveal_type(user.first_other)  # N: Revealed type is 'main.Other*'
-reveal_type(user.second_other)  # N: Revealed type is 'builtins.list*[main.Other]'
+reveal_type(user.first_other)  # N: Revealed type is "main.Other"
+reveal_type(user.second_other)  # N: Revealed type is "builtins.list[main.Other]"
 
 class Other(Base):
-    __tablename__ = 'other'
+    __tablename__ = "other"
     id = Column(Integer(), primary_key=True)
 [out]
 
@@ -158,19 +158,19 @@ from sqlalchemy.orm import relationship, RelationshipProperty
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
-    first_other = relationship('Other', uselist=False)
-    second_other = relationship('Other', uselist=True)
-    second_bad_other = relationship('What')  # E: Cannot find model "What" \
+    first_other = relationship("Other", uselist=False)
+    second_other = relationship("Other", uselist=True)
+    second_bad_other = relationship("What")  # E: Cannot find model "What" \
                                              # N: Only imported models can be found; use "if TYPE_CHECKING: ..." to avoid import cycles
 
 user = User()
-reveal_type(user.first_other)  # N: Revealed type is 'main.Other*'
-reveal_type(user.second_other)  # N: Revealed type is 'builtins.list*[main.Other]'
+reveal_type(user.first_other)  # N: Revealed type is "main.Other"
+reveal_type(user.second_other)  # N: Revealed type is "builtins.list[main.Other]"
 
 class Other(Base):
-    __tablename__ = 'other'
+    __tablename__ = "other"
     id = Column(Integer(), primary_key=True)
 [out]
 
@@ -183,15 +183,15 @@ from typing import List
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
-    first_other: RelationshipProperty[Other] = relationship('Other')
+    first_other: RelationshipProperty[Other] = relationship("Other")
     second_other: RelationshipProperty[List[Other]] = relationship(Other, uselist=True)
     third_other: RelationshipProperty[Other] = relationship(Other, uselist=False)
-    bad_other: RelationshipProperty[Other] = relationship('Other', uselist=True)  # E: Incompatible types in assignment (expression has type "RelationshipProperty[List[Other]]", variable has type "RelationshipProperty[Other]")
+    bad_other: RelationshipProperty[Other] = relationship("Other", uselist=True)  # E: Incompatible types in assignment (expression has type "RelationshipProperty[List[Other]]", variable has type "RelationshipProperty[Other]")
 
 class Other(Base):
-    __tablename__ = 'other'
+    __tablename__ = "other"
     id = Column(Integer(), primary_key=True)
 [out]
 
@@ -202,12 +202,12 @@ from sqlalchemy import Column, Integer, String
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
-    name = Column(String(), default='John Doe', nullable=True)
+    name = Column(String(), default="John Doe", nullable=True)
 
 user: User
-reveal_type(User.name)  # N: Revealed type is 'sqlalchemy.sql.schema.Column[Union[builtins.str, None]]'
+reveal_type(User.name)  # N: Revealed type is "sqlalchemy.sql.schema.Column[Union[builtins.str, None]]"
 [out]
 
 [case testAddedAttributesDeclared]
@@ -217,13 +217,13 @@ from sqlalchemy import Column, Integer, String
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
-    name = Column(String(), default='John Doe', nullable=True)
+    name = Column(String(), default="John Doe", nullable=True)
 
 user: User
-reveal_type(User.metadata)  # N: Revealed type is 'sqlalchemy.sql.schema.MetaData'
-reveal_type(User.__table__)  # N: Revealed type is 'sqlalchemy.sql.schema.Table'
+reveal_type(User.metadata)  # N: Revealed type is "sqlalchemy.sql.schema.MetaData"
+reveal_type(User.__table__)  # N: Revealed type is "sqlalchemy.sql.schema.Table"
 [out]
 
 [case testAddedAttributedDecorated]
@@ -235,13 +235,13 @@ class Base:
     ...
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
-    name = Column(String(), default='John Doe', nullable=True)
+    name = Column(String(), default="John Doe", nullable=True)
 
 user: User
-reveal_type(User.metadata)  # N: Revealed type is 'sqlalchemy.sql.schema.MetaData'
-reveal_type(User.__table__)  # N: Revealed type is 'sqlalchemy.sql.schema.Table'
+reveal_type(User.metadata)  # N: Revealed type is "sqlalchemy.sql.schema.MetaData"
+reveal_type(User.__table__)  # N: Revealed type is "sqlalchemy.sql.schema.Table"
 [out]
 
 [case testKwArgsModelOK]
@@ -251,11 +251,11 @@ from sqlalchemy.ext.declarative import declarative_base
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer, primary_key=True)
     name = Column(String)
 
-record = {'name': 'John Doe'}
+record = {"name": "John Doe"}
 User(**record)  # OK
 [out]
 
@@ -263,20 +263,20 @@ User(**record)  # OK
 from sqlalchemy import Column, String, text
 from sqlalchemy.sql.elements import Grouping
 
-reveal_type(Grouping(Column(String, nullable=False)))  # N: Revealed type is 'sqlalchemy.sql.elements.Grouping[builtins.str*]'
-reveal_type(Grouping(text('foo')))  # N: Revealed type is 'sqlalchemy.sql.elements.Grouping[None]'
+reveal_type(Grouping(Column(String, nullable=False)))  # N: Revealed type is "sqlalchemy.sql.elements.Grouping[builtins.str]"
+reveal_type(Grouping(text("foo")))  # N: Revealed type is "sqlalchemy.sql.elements.Grouping[None]"
 
 [case testDeclarativeBaseWithBaseClass]
 from sqlalchemy import Column, Integer, String
 from base import Base
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
     name = Column(String())
 
 user: User
-reveal_type(user.f())  # N: Revealed type is 'builtins.str'
+reveal_type(user.f())  # N: Revealed type is "builtins.str"
 
 [file base.py]
 from sqlalchemy.ext.declarative import declarative_base
@@ -291,13 +291,13 @@ from sqlalchemy import Column, Integer, String
 from base import Base
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer(), primary_key=True)
     name = Column(String())
 
 user: User
-reveal_type(user.f())  # N: Revealed type is 'builtins.str'
-reveal_type(user.g())  # N: Revealed type is 'builtins.int'
+reveal_type(user.f())  # N: Revealed type is "builtins.str"
+reveal_type(user.g())  # N: Revealed type is "builtins.int"
 
 [file base.py]
 from sqlalchemy.ext.declarative import declarative_base
@@ -317,5 +317,5 @@ class M1:
 class M2(M1):
     ...
 Base = declarative_base(cls=(M1, M2))  # E: Not able to calculate MRO for declarative base
-reveal_type(Base)  # N: Revealed type is 'Any'
+reveal_type(Base)  # N: Revealed type is "Any"
 [out]

--- a/test/test-data/sqlalchemy-sql-elements.test
+++ b/test/test-data/sqlalchemy-sql-elements.test
@@ -5,7 +5,7 @@ from sqlalchemy import Integer
 from sqlalchemy.sql.elements import TypeClause
 
 clause = TypeClause(Integer())
-reveal_type(clause.type)  # N: Revealed type is 'sqlalchemy.sql.type_api.TypeEngine[builtins.int*]'
+reveal_type(clause.type)  # N: Revealed type is "sqlalchemy.sql.type_api.TypeEngine[builtins.int]"
 [out]
 
 [case testNull]
@@ -14,7 +14,7 @@ from typing import Any
 from sqlalchemy.sql.elements import Null
 
 null = Null()
-reveal_type(null.type)  # N: Revealed type is 'sqlalchemy.sql.sqltypes.NullType'
+reveal_type(null.type)  # N: Revealed type is "sqlalchemy.sql.sqltypes.NullType"
 [out]
 
 [case testFalse_]
@@ -23,7 +23,7 @@ from typing import Any
 from sqlalchemy.sql.elements import False_
 
 false_ = False_()
-reveal_type(false_.type)  # N: Revealed type is 'sqlalchemy.sql.sqltypes.Boolean'
+reveal_type(false_.type)  # N: Revealed type is "sqlalchemy.sql.sqltypes.Boolean"
 [out]
 
 [case testTrue_]
@@ -32,7 +32,7 @@ from typing import Any
 from sqlalchemy.sql.elements import True_
 
 true_ = True_()
-reveal_type(true_.type)  # N: Revealed type is 'sqlalchemy.sql.sqltypes.Boolean'
+reveal_type(true_.type)  # N: Revealed type is "sqlalchemy.sql.sqltypes.Boolean"
 [out]
 
 [case testTupleInferred]
@@ -42,7 +42,7 @@ from sqlalchemy import Boolean
 from sqlalchemy.sql.elements import Tuple, Null, False_
 
 tp = Tuple(Null(), False_())
-reveal_type(tp.type)  # N: Revealed type is 'sqlalchemy.sql.type_api.TypeEngine[None]'
+reveal_type(tp.type)  # N: Revealed type is "sqlalchemy.sql.type_api.TypeEngine[None]"
 [out]
 
 [case testTupleExplicit]
@@ -52,7 +52,7 @@ from sqlalchemy import Boolean
 from sqlalchemy.sql.elements import Tuple, Null, False_
 
 tp = Tuple(Null(), False_(), type_=Boolean)
-reveal_type(tp.type)  # N: Revealed type is 'sqlalchemy.sql.type_api.TypeEngine[builtins.bool*]'
+reveal_type(tp.type)  # N: Revealed type is "sqlalchemy.sql.type_api.TypeEngine[builtins.bool]"
 [out]
 
 [case testTupleExplicitInstance]
@@ -62,7 +62,7 @@ from sqlalchemy import Boolean
 from sqlalchemy.sql.elements import Tuple, Null, False_
 
 tp = Tuple(Null(), False_(), type_=Boolean())
-reveal_type(tp.type)  # N: Revealed type is 'sqlalchemy.sql.type_api.TypeEngine[builtins.bool*]'
+reveal_type(tp.type)  # N: Revealed type is "sqlalchemy.sql.type_api.TypeEngine[builtins.bool]"
 [out]
 
 [case testCase]
@@ -72,7 +72,7 @@ from sqlalchemy import Column, case
 
 column: Column[Any]
 lst: List[Any]
-reveal_type(case(value=column, whens={item: i for i, item in enumerate(lst)}))  # N: Revealed type is 'sqlalchemy.sql.elements.Case[builtins.int*]'
+reveal_type(case(value=column, whens={item: i for i, item in enumerate(lst)}))  # N: Revealed type is "sqlalchemy.sql.elements.Case[builtins.int]"
 [out]
 
 [case testCast]
@@ -84,10 +84,10 @@ from sqlalchemy import Column, String, ARRAY, cast
 Base: Any = declarative_base()
 
 class Model(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     tags = Column(ARRAY(String(16)), nullable=False)
 
 tags: Set[str] = set()
-reveal_type(cast(tags, Model.tags.type))  # N: Revealed type is 'sqlalchemy.sql.elements.Cast[builtins.list*[builtins.str]]'
+reveal_type(cast(tags, Model.tags.type))  # N: Revealed type is "sqlalchemy.sql.elements.Cast[builtins.list[builtins.str]]"
 [out]
 

--- a/test/test-data/sqlalchemy-sql-schema.test
+++ b/test/test-data/sqlalchemy-sql-schema.test
@@ -4,15 +4,15 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.engine.url import make_url
 
 m = MetaData()
-e = create_engine('postgresql://foo')
+e = create_engine("postgresql://foo")
 c = Connection(e)
-m.bind = 'postgresql://foo'
-m.bind = make_url('postgresql://foo')
-reveal_type(m.bind)  # N: Revealed type is 'Union[sqlalchemy.engine.base.Engine, sqlalchemy.engine.base.Connection, None]'
+m.bind = "postgresql://foo"
+m.bind = make_url("postgresql://foo")
+reveal_type(m.bind)  # N: Revealed type is "Union[sqlalchemy.engine.base.Engine, sqlalchemy.engine.base.Connection, None]"
 m.bind = e
-reveal_type(m.bind)  # N: Revealed type is 'sqlalchemy.engine.base.Engine'
+reveal_type(m.bind)  # N: Revealed type is "sqlalchemy.engine.base.Engine"
 m.bind = c
-reveal_type(m.bind)  # N: Revealed type is 'sqlalchemy.engine.base.Connection'
+reveal_type(m.bind)  # N: Revealed type is "sqlalchemy.engine.base.Connection"
 [out]
 
 [case testSequenceType]
@@ -28,26 +28,26 @@ from sqlalchemy import Column, Integer, String
 Base = declarative_base()
 
 class User(Base):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = Column(Integer, primary_key=True)
     name = Column(String)
 
 user: User
-reveal_type(user.id)  # N: Revealed type is 'builtins.int*'
-reveal_type(User.name)  # N: Revealed type is 'sqlalchemy.sql.schema.Column[Union[builtins.str, None]]'
+reveal_type(user.id)  # N: Revealed type is "builtins.int"
+reveal_type(User.name)  # N: Revealed type is "sqlalchemy.sql.schema.Column[Union[builtins.str, None]]"
 User.name.foo  # E: "Column[Optional[str]]" has no attribute "foo"
-User.name.ilike('hi')  # OK
+User.name.ilike("hi")  # OK
 User.name.ilike(5)  # E: Argument 1 to "ilike" of "ColumnOperators" has incompatible type "int"; expected "str"
 [out]
 
 [case testColumnWithForeignKey]
 from sqlalchemy import Column, Table, ForeignKey, String, Integer, MetaData
 metadata = MetaData()
-user_preference = Table('user_preference', metadata,
-    Column('pref_id', Integer, primary_key=True),
-    Column('user_id', Integer, ForeignKey("user.user_id"), nullable=False),
-    Column('pref_name', String(40), nullable=False),
-    Column('pref_value', String(100))
+user_preference = Table("user_preference", metadata,
+    Column("pref_id", Integer, primary_key=True),
+    Column("user_id", Integer, ForeignKey("user.user_id"), nullable=False),
+    Column("pref_name", String(40), nullable=False),
+    Column("pref_value", String(100))
 )
 [out]
 
@@ -59,20 +59,20 @@ from sqlalchemy import Column, ForeignKey
 Base = declarative_base()
 
 class Mytable(Base):
-    __tablename__ = 'mytable'
-    objid: Column[Optional[int]] = Column(ForeignKey('othertable.objid'), index=True)
+    __tablename__ = "mytable"
+    objid: Column[Optional[int]] = Column(ForeignKey("othertable.objid"), index=True)
 [out]
 
 [case testTableWithIndexes]
 from sqlalchemy import Column, Table, String, Integer, Index, MetaData, text, func
 metadata = MetaData()
-name_col = Column('name', String)
-test_table = Table('test', metadata,
-    Column('id', Integer, primary_key=True),
+name_col = Column("name", String)
+test_table = Table("test", metadata,
+    Column("id", Integer, primary_key=True),
     name_col,
-    Index('idx1', 'id', 'name'),
-    Index('idx1', 'id', name_col),
-    Index('idx1', 'id', func.lower(name_col)),
-    Index('idx1', 'id', text("lower(name)")),
+    Index("idx1", "id", "name"),
+    Index("idx1", "id", name_col),
+    Index("idx1", "id", func.lower(name_col)),
+    Index("idx1", "id", text("lower(name)")),
 )
 [out]

--- a/test/test-data/sqlalchemy-sql-selectable.test
+++ b/test/test-data/sqlalchemy-sql-selectable.test
@@ -114,10 +114,14 @@ main:24: note:     Got:
 main:24: note:         def __iter__(self) -> Iterator[str]
 main:25: error: List item 1 has incompatible type "str"; expected "Union[None, float, Visitable]"
 main:26: error: No overload variant of "Exists" matches argument types "bool", "List[bool]"
-main:26: note: Possible overload variant:
+main:26: note: Possible overload variants:
+main:26: note:     def __init__(self, arg: Union[None, bool, int, float, SelectBase, ScalarSelect[Any], ColumnClause[Any]], **kwargs: Any) -> Exists
+main:26: note:     def __init__(self, arg: Tuple[Union[SelectBase, ScalarSelect[Any]]], **kwargs: Any) -> Exists
+main:26: note:     def __init__(self, arg: Iterable[Union[None, bool, int, float, Visitable, ColumnClause[Any]]], **kwargs: Any) -> Exists
 main:26: note:     def __init__(self, *args: Union[None, bool, int, float, ColumnClause[Any]], **kwargs: Any) -> Exists
-main:26: note:     <3 more non-matching overloads not shown>
 main:27: error: No overload variant of "Exists" matches argument types "int", "Select"
-main:27: note: Possible overload variant:
+main:27: note: Possible overload variants:
+main:27: note:     def __init__(self, arg: Union[None, bool, int, float, SelectBase, ScalarSelect[Any], ColumnClause[Any]], **kwargs: Any) -> Exists
+main:27: note:     def __init__(self, arg: Tuple[Union[SelectBase, ScalarSelect[Any]]], **kwargs: Any) -> Exists
+main:27: note:     def __init__(self, arg: Iterable[Union[None, bool, int, float, Visitable, ColumnClause[Any]]], **kwargs: Any) -> Exists
 main:27: note:     def __init__(self, *args: Union[None, bool, int, float, ColumnClause[Any]], **kwargs: Any) -> Exists
-main:27: note:     <3 more non-matching overloads not shown>

--- a/test/test-data/sqlalchemy-sql-sqltypes.test
+++ b/test/test-data/sqlalchemy-sql-sqltypes.test
@@ -7,9 +7,9 @@ s2 = String(length=10, collation='utf8', convert_unicode='force', unicode_error=
 s3 = String(length=10, collation='utf8', convert_unicode=False, unicode_error='strict')
 [out]
 main:6: error: No overload variant of "String" matches argument types "int", "str", "bool", "str"
-main:6: note: Possible overload variant:
+main:6: note: Possible overload variants:
+main:6: note:     def __init__(self, length: Optional[int] = ..., collation: Optional[str] = ..., convert_unicode: bool = ..., _warn_on_bytestring: bool = ...) -> String
 main:6: note:     def __init__(self, length: Optional[int] = ..., collation: Optional[str] = ..., convert_unicode: str = ..., unicode_error: Optional[str] = ..., _warn_on_bytestring: bool = ...) -> String
-main:6: note:     <1 more non-matching overload not shown>
 
 [case testUnicodeInit]
 from typing import Any
@@ -20,9 +20,9 @@ u2 = Unicode(length=10, collation='utf8', convert_unicode='force', unicode_error
 u3 = Unicode(length=10, collation='utf8', convert_unicode=False, unicode_error='strict')
 [out]
 main:6: error: No overload variant of "Unicode" matches argument types "int", "str", "bool", "str"
-main:6: note: Possible overload variant:
+main:6: note: Possible overload variants:
+main:6: note:     def __init__(self, length: Optional[int] = ..., collation: Optional[str] = ..., convert_unicode: bool = ..., _warn_on_bytestring: bool = ...) -> Unicode
 main:6: note:     def __init__(self, length: Optional[int] = ..., collation: Optional[str] = ..., convert_unicode: str = ..., unicode_error: Optional[str] = ..., _warn_on_bytestring: bool = ...) -> Unicode
-main:6: note:     <1 more non-matching overload not shown>
 
 [case testUnicodeTextInit]
 from typing import Any
@@ -33,6 +33,6 @@ u2 = UnicodeText(length=10, collation='utf8', convert_unicode='force', unicode_e
 u3 = UnicodeText(length=10, collation='utf8', convert_unicode=False, unicode_error='strict')
 [out]
 main:6: error: No overload variant of "UnicodeText" matches argument types "int", "str", "bool", "str"
-main:6: note: Possible overload variant:
+main:6: note: Possible overload variants:
+main:6: note:     def __init__(self, length: Optional[int] = ..., collation: Optional[str] = ..., convert_unicode: bool = ..., _warn_on_bytestring: bool = ...) -> UnicodeText
 main:6: note:     def __init__(self, length: Optional[int] = ..., collation: Optional[str] = ..., convert_unicode: str = ..., unicode_error: Optional[str] = ..., _warn_on_bytestring: bool = ...) -> UnicodeText
-main:6: note:     <1 more non-matching overload not shown>


### PR DESCRIPTION
Check out tag v0.971 in external/mypy submodule. This is the last version for which python 2 is supported.
Fix type in _collections.pyi that shows up with later version of mypy.
Change tests to pass with python 3.8 and mypy v0.971. (platform linux -- Python 3.8.10, pytest-7.1.3, pluggy-1.0.0)